### PR TITLE
Prevent segfault of vhd-util scan on VHD with corrupt footer

### DIFF
--- a/SOURCES/0002-Prevent-segfault-of-vhd-util-scan-on-VHD-with-corrup.patch
+++ b/SOURCES/0002-Prevent-segfault-of-vhd-util-scan-on-VHD-with-corrup.patch
@@ -1,0 +1,59 @@
+From c8c799c41f45bee68274332f7426e5525d4cbc4c Mon Sep 17 00:00:00 2001
+From: Mathieu Labourier <mathieu.labourier@vates.tech>
+Date: Thu, 18 Dec 2025 19:41:52 +0100
+Subject: [PATCH] Prevent segfault of vhd-util scan on VHD with corrupt footer
+
+vhd-util scan can crash when ran against a VHD with a corrupt footer.
+
+Happens when the footer reports a VHD type that should have a parent
+(like HD_TYPE_DIFF) while having none, causing the segfault.
+
+Signed-off-by: Mathieu Labourier <mathieu.labourier@vates.tech>
+---
+ vhd/lib/vhd-util-scan.c | 12 +++++++++++-
+ 1 file changed, 11 insertions(+), 1 deletion(-)
+
+diff --git a/vhd/lib/vhd-util-scan.c b/vhd/lib/vhd-util-scan.c
+index eae9d68..17392ab 100644
+--- a/vhd/lib/vhd-util-scan.c
++++ b/vhd/lib/vhd-util-scan.c
+@@ -46,6 +46,7 @@
+ #include <sys/stat.h>
+ #include <sys/types.h>
+ 
++#include "debug.h"
+ #include "list.h"
+ #include "libvhd.h"
+ #include "lvm-util.h"
+@@ -482,6 +483,14 @@ copy_name(char *dst, const char *src)
+ static int
+ vhd_util_scan_extract_volume_name(char *dst, const char *src, size_t size)
+ {
++	ASSERT(dst);
++	ASSERT(src);
++
++	if (!*src) {
++		EPRINTF("parent name is empty\n");
++		return -EINVAL;
++	}
++
+ 	char copy[VHD_MAX_NAME_LEN], *name, *s, *c;
+ 
+ 	name = strrchr(src, '/');
+@@ -509,6 +518,7 @@ vhd_util_scan_extract_volume_name(char *dst, const char *src, size_t size)
+ 		return -EINVAL;
+ 	}
+ 
++	ASSERT(c && *c == '/');
+ 	safe_strncpy(dst, ++c, size);
+ 	return 0;
+ }
+@@ -542,7 +552,7 @@ found:
+ 	if (!err)
+ 		return copy_name(image->parent, name);
+ 
+-	return 0;
++	return err;
+ }
+ 
+ static int

--- a/SPECS/blktap.spec
+++ b/SPECS/blktap.spec
@@ -7,7 +7,7 @@
 Summary: blktap user space utilities
 Name: blktap
 Version: 3.55.5
-Release: %{?xsrel}.2%{?dist}
+Release: %{?xsrel}.3%{?dist}
 License: BSD
 Group: System/Hypervisor
 URL: https://github.com/xapi-project/blktap
@@ -40,6 +40,9 @@ Provides: blktap(nbd) = 2.0
 # XCP-ng patches
 # Required by sm (qcow2). Upstream PR: https://github.com/xapi-project/blktap/pull/417
 Patch1001: 0001-Add-an-option-to-use-backup-footer-when-vhd-util-que.patch
+
+# Upstream commit: https://github.com/xapi-project/blktap/commit/b132675928ff991aa332d4fba3e95cad9dfb0aad
+Patch1002: 0002-Prevent-segfault-of-vhd-util-scan-on-VHD-with-corrup.patch
 
 %description
 Blktap creates kernel block devices which realize I/O requests to
@@ -182,6 +185,9 @@ without requiring other libraries
 %{_libdir}/libblockcrypto.so.*
 
 %changelog
+* Thu Feb 26 2026 Mathieu Labourier <mathieu.labourier@vates.tech> - 3.55.5.6.3
+- Prevent segfault of vhd-util scan on VHD with corrupt footer
+
 * Fri Feb 13 2026 Philippe Coval <philippe.coval@vates.tech> - 3.55.5-6.2
 - Rebuild with openssl-3
 


### PR DESCRIPTION
Happens when the footer reports a VHD type that should have a parent
(like HD_TYPE_DIFF) while having none, causing the segfault.