### PR TITLE
Release 3.55.5-6.6: libqcow2: Dual license blktap package with GPLv2

### DIFF
--- a/SPECS/blktap.spec
+++ b/SPECS/blktap.spec
@@ -7,8 +7,8 @@
 Summary: blktap user space utilities
 Name: blktap
 Version: 3.55.5
-Release: %{?xsrel}.5%{?dist}
-License: BSD
+Release: %{?xsrel}.6%{?dist}
+License: BSD AND GPL-2.0-or-later
 Group: System/Hypervisor
 URL: https://github.com/xapi-project/blktap
 Source0: blktap-3.55.5.tar.gz
@@ -238,6 +238,9 @@ without requiring other libraries
 %{_libdir}/libblockcrypto.so.*
 
 %changelog
+* Fri Apr 24 2026 Anthoine Bourgeois <anthoine.bourgeois@vates.tech> - 3.55.5-6.6
+- Add GPLv2 to the RPM license list as libqcow2 use this license
+
 * Thu Apr 09 2026 Philippe Coval <philippe.coval@vates.tech> - 3.55.5-6.5
 - Fix scriptlet to use udev rule aligned to mdadm
 


### PR DESCRIPTION
### Main information

#### Context & Motivation

Beside of the QCOW2 technical work, it's important to reflect the license of
this new component in the blktap package.

The QCOW2 library `libqcow2` is GPLv2. This commit changes the `License`
field of the RPM to include the `libqcow2` license.

For now, `tapdisk` license is BSD and `libqcow2` is GPLv2 so we apply a double
license on the package.

#### Release Target

- [ ] We already defined a release target with the release team.
- [x] I haven't talked with the release team, but I have a proposed target.
- [ ] I'm not sure, let's talk about it.

<!-- Unless you have chosen "I'm not sure", you can specify the wanted release
target here: fast track, 8.3-next, 8.3-next+1, other specific target. For members
of Vates' XCP-ng team: the reference for this information is the related work
item's milestone. -->

fast track.

---

### Release Notes and Documentation

#### Explain the change to users

<!-- Write a user-facing explanation that will serve as a basis for public
announcements. Explain what has changed, what the consequences are
for users (main bugs fixed, new features, etc.).  It is not a technical changelog. -->

Dual-licensing of blktap package with GPLv2 to reflect libqcow2 license.

#### Attention points

<!-- Consequences of the changes on existing setups. Include any manual steps,
changes to default behavior, compatibility issues, etc. Anything that we should
bring to the attention of user or people offering technical support -->

N/A

#### Documentation update needed

- [ ] Yes
- [x] No
- [ ] I'm not sure, help me

<!-- If yes, explain what needs to be updated and where. If no, explain why so that
the reviewer can understand the reason. -->

EXPLANATIONS

<!-- Add links to the documentation update PRs if/when they are created. -->

PR links: N/A.

---

### Testing and regression avoidance

<!-- Consider the change itself, but also regressions that could be caused
unwillingly by the change, due to what components or code paths were touched.
It's the right time to be paranoid. Consider what could go wrong in the
worst case. -->

#### What tests have you performed?

I run `yum info blktap` on a host with the new package installed.

#### What manual tests should be performed after the build, and by whom?

<!-- Manual tests that should be repeated after the build (always consider that tests
performed before the build are not definitive proof), plus tests that we should invite
the user community to perform. -->

The simple test `yum info blktap` is enough to check that the license field is changed
after installation of the new package.
The `License` line should contain `BSD AND GPL-2.0.-or-later`.

#### What's covered by the xcp-ng-tests test suite?

<!-- If you don't know, it's the perfect time to ask someone about it, and/or to dig into
the test suite. If there are any tests that you'd like to run before the merge rather than
after, mention them too. -->

No test needed.

#### What tests have been or will be added to CI for this change? If none, explain why.

No test made as it isn't a functional change.

---

### Xen Orchestra Impact

#### Does this affect existing features in Xen Orchestra, or add new features that could be useful?

- [ ] Yes
- [X] No