### PR TITLE
Release 3.55.5-6.7

### DIFF
--- a/SOURCES/0047-qcow2-Auto-finalize-commit-job-to-avoid-never-ending.patch
+++ b/SOURCES/0047-qcow2-Auto-finalize-commit-job-to-avoid-never-ending.patch
@@ -1,0 +1,60 @@
+From 2118e999404c8bfadf7a04ae5a529dd2d8419130 Mon Sep 17 00:00:00 2001
+From: Anthoine Bourgeois <anthoine.bourgeois@vates.tech>
+Date: Tue, 14 Apr 2026 09:40:11 +0200
+Subject: [PATCH] qcow2: Auto finalize commit job to avoid never ending job
+
+With this patch the qemu code is responsible for the finalize operation
+that make the state transition from ready to pending. The query command
+is still responsible of dismiss the job to conclue it.
+
+Signed-off-by: Anthoine Bourgeois <anthoine.bourgeois@vates.tech>
+---
+ drivers/block-qcow2.c      | 5 +++--
+ qcow2/lib/util/main-loop.c | 4 ++--
+ 2 files changed, 5 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/block-qcow2.c b/drivers/block-qcow2.c
+index eb9f77b1..437c69f4 100644
+--- a/drivers/block-qcow2.c
++++ b/drivers/block-qcow2.c
+@@ -971,7 +971,7 @@ do_commit(struct qcow2_state *s, struct qcow2_request *req)
+ 
+ 	qmp_block_commit(COMMIT_JOB_ID, node, base_node, NULL, top_node, NULL, NULL,
+ 		false, false, false, 0, false, BLOCKDEV_ON_ERROR_REPORT,
+-		NULL, false, false, true, false, &local_err);
++		NULL, true, true, true, false, &local_err);
+ 
+ 	if (local_err) {
+ 		DPRINTF("qcow2_commit: error: %s\n", error_get_pretty(local_err));
+@@ -1132,7 +1132,8 @@ do_cancel_commit_job(struct qcow2_state *s, struct qcow2_request *req)
+ 		goto signal;
+ 	}
+ 
+-	if (bjob->job.status == JOB_STATUS_RUNNING) {
++	if (bjob->job.status == JOB_STATUS_RUNNING ||
++                bjob->job.status == JOB_STATUS_READY) {
+ 		if (req->sync == false) {
+ 			job_cancel_locked(&bjob->job, false);
+ 		} else {
+diff --git a/qcow2/lib/util/main-loop.c b/qcow2/lib/util/main-loop.c
+index 82d737fe..740a8164 100644
+--- a/qcow2/lib/util/main-loop.c
++++ b/qcow2/lib/util/main-loop.c
+@@ -210,12 +210,12 @@ int qemu_deinit_main_loop(void)
+ 
+     src = iohandler_get_g_source();
+     g_source_unref(src);
+-    g_source_remove(g_source_get_id(src));
++    g_source_destroy(src);
+     g_source_unref(src);
+ 
+     src = aio_get_g_source(qemu_aio_context);
+     g_source_unref(src);
+-    g_source_remove(g_source_get_id(src));
++    g_source_destroy(src);
+     g_source_unref(src);
+ 
+     g_array_free(gpollfds, TRUE);
+-- 
+2.53.0
+

--- a/SPECS/blktap.spec
+++ b/SPECS/blktap.spec
@@ -7,7 +7,7 @@
 Summary: blktap user space utilities
 Name: blktap
 Version: 3.55.5
-Release: %{?xsrel}.6%{?dist}
+Release: %{?xsrel}.7%{?dist}
 License: BSD AND GPL-2.0-or-later
 Group: System/Hypervisor
 URL: https://github.com/xapi-project/blktap
@@ -87,6 +87,7 @@ Patch1043: 0043-qcow2-support-query-command.patch
 Patch1044: 0044-tapdisk-support-new-cancel-command.patch
 Patch1045: 0045-qcow2-support-cancel-command.patch
 Patch1046: 0046-libqcow2-fix-abort-commit-without-crash.patch
+Patch1047: 0047-qcow2-Auto-finalize-commit-job-to-avoid-never-ending.patch
 
 %description
 Blktap creates kernel block devices which realize I/O requests to
@@ -238,6 +239,9 @@ without requiring other libraries
 %{_libdir}/libblockcrypto.so.*
 
 %changelog
+* Thu Apr 30 2026 Anthoine Bourgeois <anthoine.bourgeois@vates.tech> - 3.55.5-6.7
+- Fix tapdisk crash and prevent infinite coalesce
+
 * Fri Apr 24 2026 Anthoine Bourgeois <anthoine.bourgeois@vates.tech> - 3.55.5-6.6
 - Add GPLv2 to the RPM license list as libqcow2 use this license
 


### PR DESCRIPTION
2 issues fixed:
- crash of tapdisk with coalesce in ready state
- infinite coalesce on loaded guest

### Main information

#### Work Item Reference

<!-- If this change is related to a Vates internal task or issue,
please provide a work item reference (e.g., XCPNG-12345), Otherwise,
remove this section and the next one. -->

XCPNG-3239

#### Related changes (optional)

<!--When several PRs are part of a single changeset, you can either fill
the form for each PR, or just once and link towards the PR with the filled
form. In the reference PR, the one with the form filled in, list all related
PRs.

You can also mention here constraints between PRs, if useful:
merge/build order, chained builds...-->

N/A

#### Context & Motivation

<!-- Explain the context of the change, without assuming that the reviewers
know about it.  and why it would be good to accept
it as an update to XCP-ng? What problem does it solve, or benefit does it
bring. Are there known or envisioned drawbacks?

In case of an update based on an upstream's update,
the motivation, the problem being solved, or the benefit to users or
maintainers. Provide any necessary context, without assuming that the
reviewers know about it. -->

Qcow2 coalesce feature was buggy under a particular use-case: when a guest was doing a lot of writes, the commit job of the coalesce couldn't converge, leaving the job in a `ready` state and never switch to `concluded` state.
This state had 2 consequences:
1. a `cancel` of the job in `ready` state crash,
2. after the crash, the qcow2 file was corrupted.

This changeset fixes the first problem and help the commit job to converge.

#### Release Target

- [ ] We already defined a release target with the release team.
- [x] I haven't talked with the release team, but I have a proposed target.
- [ ] I'm not sure, let's talk about it.

<!-- Unless you have chosen "I'm not sure", you can specify the wanted release
target here: fast track, 8.3-next, 8.3-next+1, other specific target. For members
of Vates' XCP-ng team: the reference for this information is the related work
item's milestone. -->

8.3-next

---

### Release Notes and Documentation

#### Explain the change to users

<!-- Write a user-facing explanation that will serve as a basis for public
announcements. Explain what has changed, what the consequences are
for users (main bugs fixed, new features, etc.).  It is not a technical changelog. -->

- Fix tapdisk crash on loaded coalesce.

#### Attention points

<!-- Consequences of the changes on existing setups. Include any manual steps,
changes to default behavior, compatibility issues, etc. Anything that we should
bring to the attention of user or people offering technical support -->

N/A

#### Documentation update needed

- [ ] Yes
- [x] No
- [ ] I'm not sure, help me

<!-- If yes, explain what needs to be updated and where. If no, explain why so that
the reviewer can understand the reason. -->



<!-- Add links to the documentation update PRs if/when they are created. -->



---

### Testing and regression avoidance

<!-- Consider the change itself, but also regressions that could be caused
unwillingly by the change, due to what components or code paths were touched.
It's the right time to be paranoid. Consider what could go wrong in the
worst case. -->

#### What tests have you performed?

Manual testing of the coalesce process under different workloads.

#### What manual tests should be performed after the build, and by whom?

<!-- Manual tests that should be repeated after the build (always consider that tests
performed before the build are not definitive proof), plus tests that we should invite
the user community to perform. -->

Qcow2 tests.

#### What's covered by the xcp-ng-tests test suite?

<!-- If you don't know, it's the perfect time to ask someone about it, and/or to dig into
the test suite. If there are any tests that you'd like to run before the merge rather than
after, mention them too. -->

Coalesce tests.

#### What tests have been or will be added to CI for this change? If none, explain why.

A coalesce test with a fio writing in the guest.

---

### Xen Orchestra Impact

#### Does this affect existing features in Xen Orchestra, or add new features that could be useful?

- [ ] Yes
- [x] No

<!-- If this affects existing features, describe which features are affected and how.
If this adds new features that Xen Orchestra could leverage (not just in the UI.

There's also the back-end and the REST API), describe them. -->

https://koji.xcp-ng.org/taskinfo?taskID=104513